### PR TITLE
Fixed bug of spinning camera on Mac.

### DIFF
--- a/examples/Chapter-09/Chapter-9.cpp
+++ b/examples/Chapter-09/Chapter-9.cpp
@@ -246,14 +246,20 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif		
+
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -1530,6 +1536,10 @@ int main (int argc, char * argv[])
 	uint32 currentTime;
 	uint32 lastTime = 0U;
     
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
 
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
@@ -1617,6 +1627,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);	
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-09/Chapter-9.cpp
+++ b/examples/Chapter-09/Chapter-9.cpp
@@ -246,12 +246,14 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-09/Chapter-9.cpp
+++ b/examples/Chapter-09/Chapter-9.cpp
@@ -95,6 +95,7 @@ glm::vec3 pos = glm::vec3( 3.0f, 4.0f , 10.0f );
 
 float horizAngle = 3.14f;
 float verticAngle = 0.0f;
+int   divideFactor = 2;
 
 
 float speedo = 9.0f;
@@ -256,6 +257,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter-9", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif		
@@ -352,13 +354,13 @@ bool			event_handler(SDL_Event* event)
 			if (camera == false)
 			{
 				camera = true;
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_GetMouseState(&xpos, &ypos);
 			}
 			else
 			{
 				camera = false;
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_GetMouseState(&xpos, &ypos);
 			}
 			return true;
@@ -1587,12 +1589,12 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 			//glfwGetMousePos(&xpos,&ypos);
 			//glfwSetMousePos(windowWidth/2, windowHeight/2);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-10/Chapter-10.cpp
+++ b/examples/Chapter-10/Chapter-10.cpp
@@ -91,6 +91,7 @@ glm::vec3 BaseColor = glm::vec3(1.0f,1.0f,1.0f);
 
 float	  MixRatio  = 0.2f;
 
+int		  divideFactor = 2;
 
 int timesc = 0;
 // Vertices of a unit cube centered at origin, sides aligned with axes
@@ -166,6 +167,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -262,13 +264,13 @@ bool			event_handler(SDL_Event* event)
 			if (camera == false)
 			{
 				camera = true;
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_GetMouseState(&xpos, &ypos);
 			}
 			else
 			{
 				camera = false;
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_GetMouseState(&xpos, &ypos);
 			}
 			return true;
@@ -811,11 +813,11 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 			SDL_ShowCursor(0);
 
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 		glm::mat4 cube1 = glm::mat4();

--- a/examples/Chapter-10/Chapter-10.cpp
+++ b/examples/Chapter-10/Chapter-10.cpp
@@ -157,12 +157,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-10/Chapter-10.cpp
+++ b/examples/Chapter-10/Chapter-10.cpp
@@ -157,13 +157,19 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -749,6 +755,11 @@ int main (int argc, char * argv[])
 	glm::vec3 right = glm::vec3(sin(horizAngle - 3.14f / 2.0f), 0, cos(horizAngle - 3.14f / 2.0f));
 	glm::vec3 up = glm::cross(right, direction);
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		if (camera == true)
 		{
@@ -821,6 +832,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
 	}
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-11/Chapter-11.cpp
+++ b/examples/Chapter-11/Chapter-11.cpp
@@ -148,12 +148,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-11/Chapter-11.cpp
+++ b/examples/Chapter-11/Chapter-11.cpp
@@ -148,13 +148,19 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -965,6 +971,11 @@ int main (int argc,  char * argv[])
 	glm::vec3 right = glm::vec3(sin(horizAngle - 3.14f / 2.0f), 0, cos(horizAngle - 3.14f / 2.0f));
 	glm::vec3 up = glm::cross(right, direction);
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		
 		if (camera)
@@ -1064,6 +1075,12 @@ int main (int argc,  char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate SDL2 and ImGui

--- a/examples/Chapter-11/Chapter-11.cpp
+++ b/examples/Chapter-11/Chapter-11.cpp
@@ -103,7 +103,7 @@ glm::vec4 surface_color   = glm::vec4(0.7f,0.6f,0.18f,1.0f);
 float     bump_density    = 16.0f;
 float     bump_size		  = 0.15f;
 float     specular_factor = 0.5f;
-
+int		  divideFactor    = 2;
 
 //Plane
 point4		planeVertices[NumVerticesSQ];
@@ -157,6 +157,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -254,14 +255,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1027,11 +1028,11 @@ int main (int argc,  char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 			SDL_ShowCursor(0);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 		
 

--- a/examples/Chapter-11/Chapter-11.cpp
+++ b/examples/Chapter-11/Chapter-11.cpp
@@ -158,7 +158,7 @@ bool			initSDL()
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 #else
-		gWindow = SDL_CreateWindow("chapter10", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("chapter11", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
 
 		if (gWindow == NULL)

--- a/examples/Chapter-12/Chapter-12.cpp
+++ b/examples/Chapter-12/Chapter-12.cpp
@@ -96,6 +96,7 @@ glm::vec3 LightPos  = glm::vec3(2.0f,5.0f,10.0f);
 glm::vec3 BaseColor = glm::vec3(0.6f,0.6f,0.6f);
 
 float	  MixRatio  = 0.2f;
+int		  divideFactor = 2;
 
 int timesc = 0;
 // Vertices of a unit cube centered at origin, sides aligned with axes
@@ -227,6 +228,7 @@ bool			initSDL()
 		SDL_GetCurrentDisplayMode(0, &current);
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -323,14 +325,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1054,11 +1056,11 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 			SDL_ShowCursor(0);
 
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-12/Chapter-12.cpp
+++ b/examples/Chapter-12/Chapter-12.cpp
@@ -218,14 +218,18 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
-
-		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#ifdef __APPLE__
+		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+#else
+		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -263,7 +267,7 @@ bool			initSDL()
 					std::cout << "Error initializing ImGui! " << std::endl;
 					success = false;
 				}
-
+				
 				//Init glViewport first time;
 				resize_window(windowWidth, windowHeight);
 			}
@@ -410,7 +414,7 @@ bool			initImGui()
 void			displayGui(){
 	ImGui::Begin("Editor");
 	ImGui::SetWindowSize(ImVec2(200, 200), ImGuiSetCond_Once);
-	ImGui::SetWindowPos(ImVec2(10, 10), ImGuiSetCond_Once);
+	//ImGui::SetWindowPos(ImVec2(10, 10), ImGuiSetCond_Once);
 
 	if (ImGui::TreeNode("IBL control"))
 	{
@@ -459,7 +463,7 @@ void			displayGui(){
 	ImGui::End();
 
 	ImGui::Begin("Camera Editor");
-	ImGui::SetWindowPos(ImVec2(10, 220), ImGuiSetCond_Once);
+	//ImGui::SetWindowPos(ImVec2(10, 220), ImGuiSetCond_Once);
 	ImGui::SetWindowSize(ImVec2(340, 260), ImGuiSetCond_Once);
 
 	ImGui::Checkbox("Enable Camera", &camera);
@@ -960,6 +964,11 @@ int main (int argc, char * argv[])
 	glm::vec3 right = glm::vec3(sin(horizAngle - 3.14f / 2.0f), 0, cos(horizAngle - 3.14f / 2.0f));
 	glm::vec3 up = glm::cross(right, direction);
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 
 		if(x->map_val == 0 && (init_map == 1 || init_map == 2 || init_map == 3))
@@ -1114,6 +1123,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-12/Chapter-12.cpp
+++ b/examples/Chapter-12/Chapter-12.cpp
@@ -218,12 +218,14 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter12", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-13/Chapter-13.cpp
+++ b/examples/Chapter-13/Chapter-13.cpp
@@ -163,6 +163,7 @@ struct MaterialProperties *frontMaterial;
 int				    maxLights = 0;                  // maximum number of dynamic lights allowed by the graphic card
 Lights			   *lights = NULL;						// array of lights
 MaterialProperties *materials = NULL;
+int 				divideFactor = 2;
 
 GLuint FBO;
 GLuint ShadowMap;
@@ -213,6 +214,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -310,14 +312,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1326,11 +1328,11 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 			//SDL_ShowCursor(0);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-13/Chapter-13.cpp
+++ b/examples/Chapter-13/Chapter-13.cpp
@@ -203,14 +203,20 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -1270,6 +1276,11 @@ int main (int argc, char * argv[])
 
 	FOV = initialFoV - 5;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -1398,6 +1409,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate SDL2 and ImGui

--- a/examples/Chapter-13/Chapter-13.cpp
+++ b/examples/Chapter-13/Chapter-13.cpp
@@ -203,12 +203,14 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter13", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-14/Chapter-14.cpp
+++ b/examples/Chapter-14/Chapter-14.cpp
@@ -98,6 +98,7 @@ float zNear;
 float zFar;
 float FOV;
 float initialFoV = 45.0f;
+int   divideFactor = 2;
 
 // Scene orientation (stored as a quaternion)
 float Rotation[] = { 0.0f, 0.0f, 0.0f, 1.0f };
@@ -157,6 +158,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -254,14 +256,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -833,10 +835,10 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-14/Chapter-14.cpp
+++ b/examples/Chapter-14/Chapter-14.cpp
@@ -147,12 +147,14 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-14/Chapter-14.cpp
+++ b/examples/Chapter-14/Chapter-14.cpp
@@ -147,14 +147,20 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter14", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -772,6 +778,11 @@ int main (int argc, char * argv[])
 	
 	FOV = initialFoV;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -868,6 +879,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-15/Chapter-15.cpp
+++ b/examples/Chapter-15/Chapter-15.cpp
@@ -115,6 +115,7 @@ float zNear;
 float zFar;
 float FOV;
 float initialFoV = 45.0f;
+int   divideFactor = 2;
 
 // Scene orientation (stored as a quaternion)
 float Rotation[] = { 0.0f, 0.0f, 0.0f, 1.0f };
@@ -167,6 +168,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -264,14 +266,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1024,10 +1026,10 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth/2, windowHeight/2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth/divideFactor, windowHeight/divideFactor);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-15/Chapter-15.cpp
+++ b/examples/Chapter-15/Chapter-15.cpp
@@ -158,12 +158,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-15/Chapter-15.cpp
+++ b/examples/Chapter-15/Chapter-15.cpp
@@ -158,13 +158,19 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -964,6 +970,11 @@ int main (int argc, char * argv[])
 
 	FOV = initialFoV;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -1054,6 +1065,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-16/Chapter-16.cpp
+++ b/examples/Chapter-16/Chapter-16.cpp
@@ -144,13 +144,18 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);		
+#endif		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -950,6 +955,11 @@ int main (int argc, char * argv[])
 
 	FOV = initialFoV;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -1070,6 +1080,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-16/Chapter-16.cpp
+++ b/examples/Chapter-16/Chapter-16.cpp
@@ -144,12 +144,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-16/Chapter-16.cpp
+++ b/examples/Chapter-16/Chapter-16.cpp
@@ -99,6 +99,7 @@ float zNear;
 float zFar;
 float FOV;
 float initialFoV = 45.0f;
+int divideFactor = 2;
 
 float m10 = -15.0f,m101 = -15.0f;
 int go2 = 0;
@@ -152,9 +153,10 @@ bool			initSDL()
 		SDL_GetCurrentDisplayMode(0, &current);
 
 #ifdef __APPLE__
-		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
-		gWindow = SDL_CreateWindow("Chapter15", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);		
+		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);		
 #endif		
 		if (gWindow == NULL)
 		{
@@ -249,14 +251,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1016,10 +1018,10 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 		
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-17/Chapter-17.cpp
+++ b/examples/Chapter-17/Chapter-17.cpp
@@ -149,13 +149,19 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -959,6 +965,11 @@ int main (int argc, char * argv[])
 
 	FOV = initialFoV;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -1051,6 +1062,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGUI and SDL2

--- a/examples/Chapter-17/Chapter-17.cpp
+++ b/examples/Chapter-17/Chapter-17.cpp
@@ -107,6 +107,7 @@ float zNear;
 float zFar;
 float FOV;
 float initialFoV = 45.0f;
+int   divideFactor = 2;
 
 // Scene orientation (stored as a quaternion)
 float Rotation[] = { 0.0f, 0.0f, 0.0f, 1.0f };
@@ -158,6 +159,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -255,14 +257,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -1019,10 +1021,10 @@ int main (int argc, char * argv[])
 		if(camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 
-			horizAngle  += mouseSpeedo * float(windowWidth/2 - xpos );
-			verticAngle += mouseSpeedo * float( windowHeight/2 - ypos );
+			horizAngle  += mouseSpeedo * float(windowWidth/divideFactor - xpos );
+			verticAngle += mouseSpeedo * float( windowHeight/divideFactor - ypos );
 		}
 
 

--- a/examples/Chapter-17/Chapter-17.cpp
+++ b/examples/Chapter-17/Chapter-17.cpp
@@ -149,12 +149,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter16", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-18/Chapter-18.cpp
+++ b/examples/Chapter-18/Chapter-18.cpp
@@ -152,13 +152,19 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -763,6 +769,11 @@ int main (int argc, char * argv[])
 
 	FOV = initialFoV;
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		glm::vec3 direction(cos(verticAngle) * sin(horizAngle), sin(verticAngle), cos(verticAngle) * cos(horizAngle));
 
@@ -853,6 +864,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
 	}
 
 	//close OpenGL window and  terminate SDL2 and ImGui

--- a/examples/Chapter-18/Chapter-18.cpp
+++ b/examples/Chapter-18/Chapter-18.cpp
@@ -110,6 +110,7 @@ float zNear;
 float zFar;
 float FOV;
 float initialFoV = 45.0f;
+int   divideFactor = 2;
 
 // Scene orientation (stored as a quaternion)
 float Rotation[] = { 0.0f, 0.0f, 0.0f, 1.0f };
@@ -161,6 +162,7 @@ bool			initSDL()
 
 #ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+		divideFactor = 4;
 #else
 		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 #endif
@@ -258,14 +260,14 @@ bool			event_handler(SDL_Event* event)
 			{
 				camera = true;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(0);
 			}
 			else
 			{
 				camera = false;
 				SDL_GetMouseState(&xpos, &ypos);
-				SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+				SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 				SDL_ShowCursor(1);
 			}
 			return true;
@@ -823,10 +825,10 @@ int main (int argc, char * argv[])
 		if (camera == true)
 		{
 			SDL_GetMouseState(&xpos, &ypos);
-			SDL_WarpMouseInWindow(gWindow, windowWidth / 2, windowHeight / 2);
+			SDL_WarpMouseInWindow(gWindow, windowWidth / divideFactor, windowHeight / divideFactor);
 
-			horizAngle += mouseSpeedo * float(windowWidth / 2 - xpos);
-			verticAngle += mouseSpeedo * float(windowHeight / 2 - ypos);
+			horizAngle += mouseSpeedo * float(windowWidth / divideFactor - xpos);
+			verticAngle += mouseSpeedo * float(windowHeight / divideFactor - ypos);
 		}
 
 

--- a/examples/Chapter-18/Chapter-18.cpp
+++ b/examples/Chapter-18/Chapter-18.cpp
@@ -152,12 +152,13 @@ bool			initSDL()
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter18", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/Chapter-19/Chapter-19.cpp
+++ b/examples/Chapter-19/Chapter-19.cpp
@@ -167,13 +167,19 @@ bool			initSDL()
 		//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Chapter19", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Chapter19", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -662,7 +668,12 @@ int main (int argc, char * argv[])
 		SYNC = true;
 	//setVSync(SYNC);
 #endif
-    
+
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	while (running) {
 		currentTime = SDL_GetTicks();
 		float dTime = float(currentTime - lastTime) / 1000.0f;
@@ -714,6 +725,12 @@ int main (int argc, char * argv[])
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
     }
 
 	//close OpenGL window and  terminate ImGui and SDL2

--- a/examples/Chapter-19/Chapter-19.cpp
+++ b/examples/Chapter-19/Chapter-19.cpp
@@ -167,12 +167,13 @@ bool			initSDL()
 		//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 		//SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 16);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Chapter19", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+		gWindow = SDL_CreateWindow("Chapter19", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/DeferredShading/DeferredShading.cpp
+++ b/examples/DeferredShading/DeferredShading.cpp
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 University Of Crete & FORTH. All rights reserved.
 //
 
-//Marios Kanakis - 22/06/2016
 //Implementing basicGUI with SDL2 + ImGUI + OpenGL
 
 //Credits for the Music: http://www.bensound.com/royalty-free-music
@@ -268,7 +267,9 @@ bool	init()
         //SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-        
+
+        SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
         //Initialize SDL_mixer
         if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
         {
@@ -282,7 +283,7 @@ bool	init()
         SDL_DisplayMode current;
         SDL_GetCurrentDisplayMode(0, &current);
         
-        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
         if (gWindow == NULL)
         {
             std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -1730,7 +1731,7 @@ void	displayGui()
     
     //Sets the Window size
     ImGui::SetNextWindowSize(ImVec2(400, 160), ImGuiSetCond_FirstUseEver);
-    ImGui::SetNextWindowPos(ImVec2(10, 0));
+    //ImGui::SetNextWindowPos(ImVec2(10, 0));
     ImGui::Begin("basicCube GUI");
     static float f = 0.0f;
     
@@ -1772,7 +1773,7 @@ void	displayGui()
     
     //Second Window
     ImGui::SetNextWindowSize(ImVec2(240, 60), ImGuiSetCond_FirstUseEver);
-    ImGui::SetNextWindowPos(ImVec2(10, 200));
+    //ImGui::SetNextWindowPos(ImVec2(10, 200));
     ImGui::Begin("Music");
     ImGui::Text("Music: ");
     ImGui::SameLine(0.0f, -1.0f);

--- a/examples/DeferredShading/DeferredShading.cpp
+++ b/examples/DeferredShading/DeferredShading.cpp
@@ -268,8 +268,6 @@ bool	init()
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
-        SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
         //Initialize SDL_mixer
         if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
         {
@@ -283,7 +281,7 @@ bool	init()
         SDL_DisplayMode current;
         SDL_GetCurrentDisplayMode(0, &current);
         
-        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
         if (gWindow == NULL)
         {
             std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/RayTracing/RayTracing.cpp
+++ b/examples/RayTracing/RayTracing.cpp
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 University Of Crete & FORTH. All rights reserved.
 //
 
-//Marios Kanakis - 22/06/2016
 //Implementing basicGUI with SDL2 + ImGUI + OpenGL
 
 //Credits for the Music: http://www.bensound.com/royalty-free-music
@@ -210,6 +209,8 @@ bool	init()
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
         
+   		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
         //Initialize SDL_mixer
         if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
         {
@@ -223,7 +224,7 @@ bool	init()
         SDL_DisplayMode current;
         SDL_GetCurrentDisplayMode(0, &current);
         
-        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
         if (gWindow == NULL)
         {
             std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/RayTracing/RayTracing.cpp
+++ b/examples/RayTracing/RayTracing.cpp
@@ -209,8 +209,6 @@ bool	init()
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
         
-   		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
         //Initialize SDL_mixer
         if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
         {
@@ -224,7 +222,7 @@ bool	init()
         SDL_DisplayMode current;
         SDL_GetCurrentDisplayMode(0, &current);
         
-        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+        gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL );
         if (gWindow == NULL)
         {
             std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/basicCompute/basicCompute.cpp
+++ b/examples/basicCompute/basicCompute.cpp
@@ -128,11 +128,13 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Compute shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+		gWindow = SDL_CreateWindow("Compute shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -359,7 +361,7 @@ void	displayGui()
 
 	//Sets the Window size
 	ImGui::SetNextWindowSize(ImVec2(400, 160), ImGuiSetCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2(10, 0));
+	//ImGui::SetNextWindowPos(ImVec2(10, 0));
 	ImGui::Begin("basicCompute GUI");
 	static float f = 0.0f;
 

--- a/examples/basicCompute/basicCompute.cpp
+++ b/examples/basicCompute/basicCompute.cpp
@@ -128,13 +128,11 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
-		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Compute shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+		gWindow = SDL_CreateWindow("Compute shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/basicCubeGUI/basicCubeGUI.cpp
+++ b/examples/basicCubeGUI/basicCubeGUI.cpp
@@ -160,8 +160,9 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Initialize SDL_mixer
 		if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
 		{
@@ -175,7 +176,12 @@ bool	init()
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL4 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL4 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+#endif
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;

--- a/examples/basicCubeGUI/basicCubeGUI.cpp
+++ b/examples/basicCubeGUI/basicCubeGUI.cpp
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 University Of Crete & FORTH. All rights reserved.
 //
 
-//Marios Kanakis - 22/06/2016 
 //Implementing basicGUI with SDL2 + ImGUI + OpenGL 
 
 //Credits for the Music: http://www.bensound.com/royalty-free-music

--- a/examples/basicGeometry/basicGeometry.cpp
+++ b/examples/basicGeometry/basicGeometry.cpp
@@ -118,12 +118,14 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Geometry shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+		gWindow = SDL_CreateWindow("Geometry shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -328,7 +330,7 @@ void	displayGui()
 
 	//Sets the Window size
 	ImGui::SetNextWindowSize(ImVec2(400, 160), ImGuiSetCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2(10, 0));
+	//ImGui::SetNextWindowPos(ImVec2(10, 0));
 	ImGui::Begin("basicGeometry GUI");
 	static float f = 0.0f;
 

--- a/examples/basicGeometry/basicGeometry.cpp
+++ b/examples/basicGeometry/basicGeometry.cpp
@@ -118,14 +118,21 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Geometry shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Geometry shader example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+#endif
+
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -181,6 +188,11 @@ void	close()
 	SDL_DestroyWindow(gWindow);
 	Mix_Quit();
 	SDL_Quit();
+}
+void			resize_window(int width, int height)
+{
+    // Set OpenGL viewport and default camera
+    glViewport(0, 0, width, height);
 }
 
 bool	event_handler(SDL_Event* event)
@@ -383,6 +395,11 @@ int		main(int, char**)
 	// Init Geometry.
 	initGeoexample();
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	// Main loop
 	while (running)
 	{
@@ -405,7 +422,9 @@ int		main(int, char**)
 		ImGui_ImplSDL2_NewFrame(gWindow);
 		ImGui::NewFrame();
 		// Rendering
+#if !(defined(__APPLE__))
 		glViewport(0, 0, (int)ImGui::GetIO().DisplaySize.x, (int)ImGui::GetIO().DisplaySize.y);
+#endif
 		glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
@@ -421,6 +440,12 @@ int		main(int, char**)
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
 	}
 
 	close(); //Shuts down every little thing...

--- a/examples/basicShading/basicShading.cpp
+++ b/examples/basicShading/basicShading.cpp
@@ -6,7 +6,6 @@
 //  Copyright (c) 2012 University Of Crete & FORTH. All rights reserved.
 //
 
-//Marios Kanakis - 22/06/2016 
 //Implementing basicGUI with SDL2 + ImGUI + OpenGL 
 
 //Credits for the Music: http://www.bensound.com/royalty-free-music
@@ -187,6 +186,9 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
+
 		//Initialize SDL_mixer
 		if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
 		{
@@ -200,7 +202,7 @@ bool	init()
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -676,7 +678,7 @@ void	displayGui()
 
 	//Sets the Window size
 	ImGui::SetNextWindowSize(ImVec2(400, 160), ImGuiSetCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2(10, 0));
+	//ImGui::SetNextWindowPos(ImVec2(10, 0));
 	ImGui::Begin("basicCube GUI");
 	static float f = 0.0f;
 
@@ -718,7 +720,7 @@ void	displayGui()
 
 	//Second Window
 	ImGui::SetNextWindowSize(ImVec2(240, 60), ImGuiSetCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2( 10,200));
+	//ImGui::SetNextWindowPos(ImVec2( 10,200));
 	ImGui::Begin("Music");
 	ImGui::Text("Music: ");
 	ImGui::SameLine(0.0f, -1.0f);

--- a/examples/basicShading/basicShading.cpp
+++ b/examples/basicShading/basicShading.cpp
@@ -186,8 +186,9 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 
 		//Initialize SDL_mixer
 		if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048) < 0)
@@ -202,7 +203,13 @@ bool	init()
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("ImGui + SDL2 + OpenGL3 example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+#endif
+
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -275,6 +282,12 @@ bool	load_media()
 		success = false;
 	}
 	return success;
+}
+
+void			resize_window(int width, int height)
+{
+    // Set OpenGL viewport and default camera
+    glViewport(0, 0, width, height);
 }
 
 bool	event_handler(SDL_Event* event)
@@ -765,6 +778,11 @@ int main(int, char**)
 	//initCube();
 	initTessexample();
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	// Main loop
 	while (running)
 	{
@@ -785,7 +803,9 @@ int main(int, char**)
 		ImGui_ImplSDL2_NewFrame(gWindow);
 		ImGui::NewFrame();
 		// Rendering
+#if !(defined(__APPLE__))
 		glViewport(0, 0, (int)ImGui::GetIO().DisplaySize.x, (int)ImGui::GetIO().DisplaySize.y);
+#endif
 		glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
@@ -802,6 +822,12 @@ int main(int, char**)
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
 	}
 
 	close(); //Shuts down every little thing...

--- a/examples/basicTesselation/basicTesselation.cpp
+++ b/examples/basicTesselation/basicTesselation.cpp
@@ -120,13 +120,20 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+#ifdef __APPLE__
 		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
-
+#endif
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
+#ifdef __APPLE__
 		gWindow = SDL_CreateWindow("Tesselation shaders example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
+#else
+		gWindow = SDL_CreateWindow("Tesselation shaders example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+#endif
+		
+		
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -182,6 +189,12 @@ void	close()
 	SDL_DestroyWindow(gWindow);
 	Mix_Quit();
 	SDL_Quit();
+}
+
+void			resize_window(int width, int height)
+{
+    // Set OpenGL viewport and default camera
+    glViewport(0, 0, width, height);
 }
 
 bool	event_handler(SDL_Event* event)
@@ -374,6 +387,11 @@ int main(int, char**)
 	
 	initTessexample();
 
+#ifdef __APPLE__
+	int *w = (int*)malloc(sizeof(int));
+	int *h = (int*)malloc(sizeof(int));
+#endif
+
 	// Main loop
 	while (running)
 	{
@@ -396,7 +414,9 @@ int main(int, char**)
 		ImGui_ImplSDL2_NewFrame(gWindow);
 		ImGui::NewFrame();
 		// Rendering
+#if !(defined(__APPLE__))
 		glViewport(0, 0, (int)ImGui::GetIO().DisplaySize.x, (int)ImGui::GetIO().DisplaySize.y);
+#endif
 		glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 
@@ -413,6 +433,12 @@ int main(int, char**)
 		SDL_GL_MakeCurrent(gWindow, gContext);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 		SDL_GL_SwapWindow(gWindow);
+#ifdef __APPLE__
+		if(w!=NULL && h!=NULL){
+			SDL_GL_GetDrawableSize(gWindow, w, h);
+			resize_window(*w, *h);
+		}
+#endif
 	}
 
 	close(); //Shuts down every little thing...

--- a/examples/basicTesselation/basicTesselation.cpp
+++ b/examples/basicTesselation/basicTesselation.cpp
@@ -120,11 +120,13 @@ bool	init()
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 
+		SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
+
 		//Create Window
 		SDL_DisplayMode current;
 		SDL_GetCurrentDisplayMode(0, &current);
 
-		gWindow = SDL_CreateWindow("Tesselation shaders example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL);
+		gWindow = SDL_CreateWindow("Tesselation shaders example!", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_ALLOW_HIGHDPI );
 		if (gWindow == NULL)
 		{
 			std::cout << "Window could not be created! SDL Error: " << SDL_GetError() << std::endl;
@@ -320,7 +322,7 @@ void	displayGui()
 
 	//Sets the Window size
 	ImGui::SetNextWindowSize(ImVec2(400, 160), ImGuiSetCond_FirstUseEver);
-	ImGui::SetNextWindowPos(ImVec2(10, 0));
+	//ImGui::SetNextWindowPos(ImVec2(10, 0));
 	ImGui::Begin("basicTesselation GUI");
 	static float f = 0.0f;
 


### PR DESCRIPTION
Since we use the HIGHDPI option for mac, some divisions with the width and height of the display window must now be changed for the case of macOS.

The main changes were that the divisions **windowHeight/2** and **windowWidth/2** are now changed to **windowHeight/divideFactor** and **windowWidth/divideFactor**, where:

**divideFactor == 2 (Windows/Linux case)**
**divideFactor == 4 (macOS case)**